### PR TITLE
[Bob] Add file size validation to prevent large uploads

### DIFF
--- a/backend/routes/files.js
+++ b/backend/routes/files.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const fileService = require('../services/fileService');
+const validator = require('../utils/validator');
 
 /**
  * GET /api/files
@@ -28,6 +29,15 @@ router.get('/', async (req, res) => {
  */
 router.post('/upload', async (req, res) => {
   try {
+    // Validate file data before upload
+    const validation = validator.validateFile(req.body);
+    if (!validation.valid) {
+      return res.status(400).json({
+        success: false,
+        error: validation.error
+      });
+    }
+
     const file = await fileService.uploadFile(req.body);
     res.status(201).json({
       success: true,
@@ -35,9 +45,9 @@ router.post('/upload', async (req, res) => {
       data: file
     });
   } catch (error) {
-    res.status(400).json({ 
+    res.status(400).json({
       success: false,
-      error: error.message 
+      error: error.message
     });
   }
 });

--- a/tests/files.test.js
+++ b/tests/files.test.js
@@ -81,6 +81,70 @@ describe('File API Endpoints', () => {
       expect(response.body.success).toBe(false);
       expect(response.body.error).toContain('size');
     });
+
+    test('should reject file exceeding 100MB size limit', async () => {
+      const fileData = {
+        name: 'large-file.mp4',
+        size: 101 * 1024 * 1024, // 101MB
+        type: 'video/mp4'
+      };
+
+      const response = await request(app)
+        .post('/api/files/upload')
+        .send(fileData);
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('100MB');
+    });
+
+    test('should accept file at exactly 100MB', async () => {
+      const fileData = {
+        name: 'max-size-file.mp4',
+        size: 100 * 1024 * 1024, // Exactly 100MB
+        type: 'video/mp4'
+      };
+
+      const response = await request(app)
+        .post('/api/files/upload')
+        .send(fileData);
+
+      expect(response.status).toBe(201);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.size).toBe(100 * 1024 * 1024);
+    });
+
+    test('should reject file with zero size', async () => {
+      const fileData = {
+        name: 'empty-file.txt',
+        size: 0,
+        type: 'text/plain'
+      };
+
+      const response = await request(app)
+        .post('/api/files/upload')
+        .send(fileData);
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('greater than 0');
+    });
+
+    test('should reject file with negative size', async () => {
+      const fileData = {
+        name: 'invalid-file.txt',
+        size: -1024,
+        type: 'text/plain'
+      };
+
+      const response = await request(app)
+        .post('/api/files/upload')
+        .send(fileData);
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('greater than 0');
+    });
   });
 
   describe('GET /api/files/:id', () => {


### PR DESCRIPTION
## Summary

This PR implements file size validation to prevent uploads exceeding 100MB, addressing issue #1.

## Changes Made

### Backend Changes
- **`backend/routes/files.js`**: Integrated `validator.validateFile()` in the upload route to enforce validation before file upload
- Added early return with 400 status code for invalid files

### Test Coverage
- **`tests/files.test.js`**: Added 4 comprehensive test cases:
  - ✅ Reject files exceeding 100MB limit
  - ✅ Accept files at exactly 100MB (boundary test)
  - ✅ Reject files with zero size
  - ✅ Reject files with negative size

## Test Results

```
Test Suites: 2 passed, 2 total
Tests:       34 passed, 34 total
Coverage:    89.83% statements
```

## Validation Logic

The existing `validator.js` already contained:
- `MAX_FILE_SIZE` constant set to 100MB
- `validateFileSize()` function with proper error messages
- `validateFile()` function that validates name, size, and type

This PR connects the validation to the upload endpoint.

## Error Response Example

```json
{
  "success": false,
  "error": "File size exceeds maximum allowed size of 100MB"
}
```

## Acceptance Criteria Met

- ✅ MAX_FILE_SIZE constant exists (100MB)
- ✅ File size validated in upload endpoint
- ✅ Returns 400 error with clear message for oversized files
- ✅ Added comprehensive test coverage

## Files Modified

- `backend/routes/files.js` - Added validation middleware
- `tests/files.test.js` - Added 4 new test cases

Fixes #1